### PR TITLE
fix: downloads page variables initialization

### DIFF
--- a/modules/downloads.php
+++ b/modules/downloads.php
@@ -17,9 +17,9 @@ try {
 	
 	if(!mconfig('active')) throw new Exception(lang('error_47',true));
 	
-	$downloadCLIENTS = '';
-	$downloadPATCHES = '';
-	$downloadTOOLS = '';
+	$downloadCLIENTS = [];
+	$downloadPATCHES = [];
+	$downloadTOOLS = [];
 	
 	$downloadsCACHE = loadCache('downloads.cache');
 	if(is_array($downloadsCACHE)) {


### PR DESCRIPTION
Fixed loading of the download page.

Tested with PHP 7.4 and 8.3